### PR TITLE
fix error when using built-in reference genome

### DIFF
--- a/macros_conffiles.xml
+++ b/macros_conffiles.xml
@@ -328,7 +328,9 @@ show_tick_labels    = yes
     <configfile name="test_case_conf"><![CDATA[
 <!--
 mkdir -p test-data/my-test-case/;
-cp ${genome_fasta} test-data/my-test-case/input.fa;
+#if $reference_genome.reference_genome_source == 'history':
+    cp ${genome_fasta} test-data/my-test-case/input.fa;
+#end if
 #if $ideogram.bands:
 cp ${ideogram.bands} test-data/my-test-case/bands.${ideogram.bands.ext};
 #end if


### PR DESCRIPTION
tool complained that `genome_fasta` could not be found when using a built-in reference genome